### PR TITLE
Assign level roles when member levels up

### DIFF
--- a/Onyix/Commands/Level.cs
+++ b/Onyix/Commands/Level.cs
@@ -25,7 +25,7 @@ namespace Onyix.Commands
 	public class Level : ApplicationCommandModule
 	{
 		[SlashCommand("level", "Displays your current level in this guild.", true)]
-		public async Task Execute(InteractionContext ctx,
+		public static async Task Execute(InteractionContext ctx,
 			[Option("user", "Get the level for a specific user")] DiscordUser? target = null)
 		{
 			// Check if interaction occured in a guild
@@ -40,7 +40,7 @@ namespace Onyix.Commands
 				await ctx.CreateResponseAsync(new DiscordEmbedBuilder()
 					.WithTitle("Error")
 					.WithDescription("Bots cannot participate in the level system.")
-					.WithColor(Colors.Red));
+					.WithColor(Colors.Red), true);
 
 				return;
 			}
@@ -56,7 +56,7 @@ namespace Onyix.Commands
 				.WithThumbnail(target.AvatarUrl)
 				.AddField("Level", user.Level.ToString(), true)
 				.AddField("Total XP", user.TotalXP.ToString(), true)
-				.AddField("Progress to next level", Levels.GetLevelProgress(user, settings), false));
+				.AddField("Progress to next level", Levels.GetLevelProgress(user, settings), false), true);
 		}
 	}
 }

--- a/Onyix/Levels.cs
+++ b/Onyix/Levels.cs
@@ -19,6 +19,7 @@ using DSharpPlus.Entities;
 using DSharpPlus.EventArgs;
 using Onyix.Entities;
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Onyix
@@ -32,7 +33,7 @@ namespace Onyix
 			LevelSettings settings = Database.GetLevelSettings(e.Guild.Id);
 
 			// Check if we can give XP right now
-			if ((DateTime.Now - user.LastGain) >= TimeSpan.FromSeconds(settings.Cooldown) is not true) return;
+			//if ((DateTime.Now - user.LastGain) >= TimeSpan.FromSeconds(settings.Cooldown) is not true) return;
 			
 			// Give XP
 			user.XP += settings.XpPerMessage;
@@ -44,6 +45,15 @@ namespace Onyix
 			{
 				user.XP = 0;
 				user.Level++;
+
+				// Assign level roles
+				if (settings.LevelRoles.ContainsKey(user.Level))
+				{
+					DiscordRole role = e.Guild.GetRole(settings.LevelRoles[user.Level]);
+					DiscordMember member = await e.Guild.GetMemberAsync(e.Author.Id);
+
+					await member.GrantRoleAsync(role);
+				}
 
 				// Check if we can send level up message
 				if (settings.EnableLevelUpMessage)


### PR DESCRIPTION
Onyix will now assign the role for a level to a member when they reach that level.

Closes #4 